### PR TITLE
Updated Tabkiller for Firefox 4

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -65,7 +65,7 @@
       <!-- Firefox -->
       <RDF:Description em:id="{ec8030f7-c20a-464f-9b0e-13a3a9e97384}"
                        em:minVersion="3.0"
-                       em:maxVersion="3.7a1pre" />
+                       em:maxVersion="4.0" />
     </em:targetApplication>
   </RDF:Description>
 </RDF:RDF>


### PR DESCRIPTION
Tabkiller works in Firefox 4. The only reason it won't install is because the maxVersion element is set to 3.7pre1. Updating that element allows Tabkiller to install and run on Firefox 4 without issues.
